### PR TITLE
feat: إضافة تكوين للنشر على Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "bunx rork start -p qreucjy2fsd7wq0ey6lhs --tunnel",
     "start-web": "bunx rork start -p qreucjy2fsd7wq0ey6lhs --web --tunnel",
     "start-web-dev": "DEBUG=expo* bunx rork start -p qreucjy2fsd7wq0ey6lhs --web --tunnel",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "build:web": "expo export -p web"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "buildCommand": "expo export -p web",
+  "outputDirectory": "dist",
+  "devCommand": "expo",
+  "cleanUrls": true,
+  "framework": null,
+  "rewrites": [
+    {
+      "source": "/:path*",
+      "destination": "/"
+    }
+  ]
+}


### PR DESCRIPTION
تمت إضافة ملف `vercel.json` لتكوين عملية البناء والنشر على Vercel.

يتضمن هذا التغيير أيضًا إضافة برنامج نصي `build:web` إلى `package.json` لتسهيل إنشاء إصدار الويب محليًا.